### PR TITLE
Add missing slash to link.

### DIFF
--- a/compilers.org
+++ b/compilers.org
@@ -7,7 +7,7 @@ Menu: [[file:bash.org][bash]] | [[file:compilers.org][Compilers]] | [[file:go.or
 
 
 * Inbox
-+ [[http://c9x.me/comp-bib][Resources for Amateur Compiler Writers]]
++ [[http://c9x.me/comp-bib/][Resources for Amateur Compiler Writers]]
 + [[https://news.ycombinator.com/item?id=10786842][Want to Write a Compiler? Read These Two Papers - HN]]
 + [[https://news.ycombinator.com/item?id=10785164][An Incremental Approach to Compiler Construction - HN]]
 + [[http://ruslanspivak.com/lsbasi-part6][Let's Build a Simple Interpreter - Part 6]]


### PR DESCRIPTION
The link without slash gives a 404 on the target website.

Note that, I could also fix my nginx configuration... But I'd rather do it once the HN rush went through.
